### PR TITLE
Updating ESTER's vignette metadata

### DIFF
--- a/vignettes/ESTER.Rmd
+++ b/vignettes/ESTER.Rmd
@@ -3,6 +3,10 @@ title: "Efficient Sequential Testing with Evidence Ratios"
 author: "Ladislas Nalborczyk"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Efficient Sequential Testing with Evidence Ratios}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
 ---
 
 ## (Information) Theoretical background


### PR DESCRIPTION
En principe ça devrait être bon. En tout les metadata que j'ai rajouté me permettent d'utiliser `devtools::build_vignettes()` !

Il faut juste voir ce qu'en dit Travis.